### PR TITLE
Add Navigation 3 with product list and detail screens



### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,11 +2,12 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
     namespace = "com.shayan.android101"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.shayan.android101"
@@ -55,6 +56,10 @@ dependencies {
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.client.logging)
     implementation(libs.ktor.serialization.gson)
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+    implementation(libs.kotlinx.serialization.core)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/shayan/android101/MainActivity.kt
+++ b/app/src/main/java/com/shayan/android101/MainActivity.kt
@@ -4,20 +4,53 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.lifecycle.ViewModelProvider
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import com.shayan.android101.navigation.ProductDetailRoute
+import com.shayan.android101.navigation.ProductListRoute
+import com.shayan.android101.ui.screens.ProductListScreen
 import com.shayan.android101.ui.screens.ProductScreen
 import com.shayan.android101.ui.theme.Android101Theme
+import com.shayan.android101.viewmodels.ProductListViewModel
 import com.shayan.android101.viewmodels.ProductViewModel
+import com.shayan.android101.viewmodels.ProductViewModelFactory
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val productViewModel = ViewModelProvider(this)[ProductViewModel::class.java]
-
         enableEdgeToEdge()
         setContent {
             Android101Theme {
-                ProductScreen(productViewModel)
+                val backStack = remember { mutableStateListOf<Any>(ProductListRoute) }
+
+                NavDisplay(
+                    backStack = backStack,
+                    onBack = { backStack.removeLastOrNull() },
+                    entryProvider = entryProvider {
+                        entry<ProductListRoute> {
+                            val viewModel: ProductListViewModel = viewModel()
+                            ProductListScreen(
+                                viewModel = viewModel,
+                                onProductClick = { productId ->
+                                    backStack.add(ProductDetailRoute(productId))
+                                }
+                            )
+                        }
+
+                        entry<ProductDetailRoute> { route ->
+                            val viewModel: ProductViewModel = viewModel(
+                                factory = ProductViewModelFactory(route.productId)
+                            )
+                            ProductScreen(
+                                viewModel = viewModel,
+                                onBackClick = { backStack.removeLastOrNull() }
+                            )
+                        }
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/shayan/android101/navigation/Routes.kt
+++ b/app/src/main/java/com/shayan/android101/navigation/Routes.kt
@@ -1,0 +1,5 @@
+package com.shayan.android101.navigation
+
+data object ProductListRoute
+
+data class ProductDetailRoute(val productId: Int)

--- a/app/src/main/java/com/shayan/android101/network/FakeStoreApi.kt
+++ b/app/src/main/java/com/shayan/android101/network/FakeStoreApi.kt
@@ -9,4 +9,8 @@ class FakeStoreApi {
     private val baseUrl = "https://shayanhimself.github.io/fake-store-api"
 
     suspend fun getProduct(id: Int): Product = client.get("$baseUrl/products/$id.json").body()
+
+    suspend fun getAllProducts(): List<Product> {
+        return (1..5).map { id -> getProduct(id) }
+    }
 }

--- a/app/src/main/java/com/shayan/android101/ui/components/MyAppBar.kt
+++ b/app/src/main/java/com/shayan/android101/ui/components/MyAppBar.kt
@@ -1,6 +1,10 @@
 package com.shayan.android101.ui.components
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -13,13 +17,26 @@ import com.shayan.android101.ui.theme.Orange500
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MyTopAppBar() {
+fun MyTopAppBar(
+    onBackClick: (() -> Unit)? = null,
+) {
     TopAppBar(
         title = {
             Text(
                 text = stringResource(R.string.app_name),
                 style = MaterialTheme.typography.headlineSmall,
             )
+        },
+        navigationIcon = {
+            if (onBackClick != null) {
+                IconButton(onClick = onBackClick) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        tint = BlueDark
+                    )
+                }
+            }
         },
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = Orange500,

--- a/app/src/main/java/com/shayan/android101/ui/screens/ProductListScreen.kt
+++ b/app/src/main/java/com/shayan/android101/ui/screens/ProductListScreen.kt
@@ -1,0 +1,164 @@
+package com.shayan.android101.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.shayan.android101.R
+import com.shayan.android101.datamodel.Product
+import com.shayan.android101.ui.components.MyTopAppBar
+import com.shayan.android101.ui.theme.SpacingL
+import com.shayan.android101.ui.theme.SpacingM
+import com.shayan.android101.viewmodels.ProductListViewModel
+
+@Composable
+fun ProductListScreen(
+    viewModel: ProductListViewModel,
+    onProductClick: (Int) -> Unit,
+) {
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
+    ProductListScreen(
+        viewState = viewState,
+        onRefresh = viewModel::onRefresh,
+        onProductClick = onProductClick,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ProductListScreen(
+    viewState: ProductListViewModel.ViewState,
+    onRefresh: () -> Unit,
+    onProductClick: (Int) -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = { MyTopAppBar() }
+    ) { innerPadding ->
+        PullToRefreshBox(
+            isRefreshing = viewState.isLoading,
+            onRefresh = onRefresh,
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            if (viewState.products.isNotEmpty()) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(SpacingM),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(SpacingM)
+                ) {
+                    items(viewState.products, key = { it.id }) { product ->
+                        ProductListItem(
+                            product = product,
+                            onClick = { onProductClick(product.id) }
+                        )
+                    }
+                }
+            }
+
+            if (viewState.hasError) {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Text(
+                        text = stringResource(R.string.error_general),
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(SpacingL))
+                    Button(onClick = onRefresh) {
+                        Text(
+                            text = stringResource(R.string.retry),
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(horizontal = SpacingM),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProductListItem(
+    product: Product,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpacingM),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                model = product.image,
+                contentDescription = product.title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.size(80.dp)
+            )
+
+            Spacer(modifier = Modifier.width(SpacingM))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = product.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = stringResource(R.string.price_formatted, product.price),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+
+                Text(
+                    text = stringResource(R.string.rating_formatted, product.rating.rate, product.rating.count),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/shayan/android101/ui/screens/ProductScreen.kt
+++ b/app/src/main/java/com/shayan/android101/ui/screens/ProductScreen.kt
@@ -45,11 +45,13 @@ import com.shayan.android101.viewmodels.ProductViewModel
 @Composable
 fun ProductScreen(
     viewModel: ProductViewModel,
+    onBackClick: () -> Unit,
 ) {
     val viewState by viewModel.viewState.collectAsStateWithLifecycle()
     ProductScreen(
         viewState = viewState,
-        onRefresh = viewModel::onRefresh
+        onRefresh = viewModel::onRefresh,
+        onBackClick = onBackClick,
     )
 }
 
@@ -58,12 +60,13 @@ fun ProductScreen(
 private fun ProductScreen(
     viewState: ProductViewModel.ViewState,
     onRefresh: () -> Unit,
+    onBackClick: () -> Unit,
 ) {
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background),
-        topBar = { MyTopAppBar() }
+        topBar = { MyTopAppBar(onBackClick = onBackClick) }
     ) { innerPadding ->
         PullToRefreshBox(
             isRefreshing = viewState.isLoading,
@@ -209,6 +212,7 @@ fun ProductScreenDarkPreview() {
                 isLoading = false,
             ),
             onRefresh = {},
+            onBackClick = {},
         )
     }
 }
@@ -223,6 +227,7 @@ fun ProductScreenLoadingPreview() {
                 isLoading = true,
             ),
             onRefresh = {},
+            onBackClick = {},
         )
     }
 }
@@ -238,6 +243,7 @@ fun ProductScreenErrorPreview() {
                 hasError = true,
             ),
             onRefresh = {},
+            onBackClick = {},
         )
     }
 }

--- a/app/src/main/java/com/shayan/android101/viewmodels/ProductListViewModel.kt
+++ b/app/src/main/java/com/shayan/android101/viewmodels/ProductListViewModel.kt
@@ -7,10 +7,10 @@ import com.shayan.android101.network.FakeStoreApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
-class ProductViewModel(private val productId: Int) : ViewModel() {
+class ProductListViewModel : ViewModel() {
 
-    class ViewState(
-        val product: Product? = null,
+    data class ViewState(
+        val products: List<Product> = emptyList(),
         val isLoading: Boolean = false,
         val hasError: Boolean = false,
     )
@@ -19,21 +19,21 @@ class ProductViewModel(private val productId: Int) : ViewModel() {
 
     val viewState = MutableStateFlow(ViewState(isLoading = true))
 
-    private fun fetchProduct() = viewModelScope.launch {
+    private fun fetchProducts() = viewModelScope.launch {
         try {
-            val product = api.getProduct(productId)
-            viewState.value = ViewState(product = product)
+            val products = api.getAllProducts()
+            viewState.value = ViewState(products = products)
         } catch (e: Exception) {
             viewState.value = ViewState(hasError = true)
         }
     }
 
     init {
-        fetchProduct()
+        fetchProducts()
     }
 
     fun onRefresh() {
         viewState.value = ViewState(isLoading = true)
-        fetchProduct()
+        fetchProducts()
     }
 }

--- a/app/src/main/java/com/shayan/android101/viewmodels/ProductViewModelFactory.kt
+++ b/app/src/main/java/com/shayan/android101/viewmodels/ProductViewModelFactory.kt
@@ -1,0 +1,13 @@
+package com.shayan.android101.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class ProductViewModelFactory(
+    private val productId: Int,
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return ProductViewModel(productId) as T
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.7.3"
-kotlin = "2.0.0"
+kotlin = "2.1.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -10,6 +10,9 @@ activityCompose = "1.9.3"
 composeBom = "2024.12.01"
 coil = "2.7.0"
 ktor = "3.0.3"
+nav3 = "1.0.1"
+lifecycleViewmodelNav3 = "2.9.0"
+kotlinxSerializationCore = "1.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -32,9 +35,14 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-serialization-gson = { module = "io.ktor:ktor-serialization-gson", version.ref = "ktor" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 


### PR DESCRIPTION
Set up Jetpack Navigation 3 (androidx.navigation3 1.0.1) with NavDisplay
and entryProvider to navigate between a new ProductListScreen and the
existing ProductDetailScreen. Add back button support to the app bar,
ProductListViewModel for fetching all products, and a ViewModelFactory
for passing productId to the detail screen.

https://claude.ai/code/session_011zAxyi9TRLLYE9LE9hNCMD